### PR TITLE
WIP: Modify default variables and interpolate some common ansible args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ clouds.yaml*
 packer-manifest.json
 s3cfg
 venv
+
+# Ignore direnv file
+.envrc

--- a/packer/kubernetes.pkr.hcl
+++ b/packer/kubernetes.pkr.hcl
@@ -27,7 +27,7 @@ variable "volume_size" {
   default = 10
 }
 
-variable "disk_format" {
+variable "disk_format" { # Same thing as build_target?
   type = string
   default = "qcow2"
 }
@@ -40,48 +40,62 @@ variable "ssh_username" {
   type = string
 }
 
+variable "kubernetes_version" {
+  type = string
+}
+
 #####
 # Kubernetes-specific variables
 #####
 
 variable "additional_executables" {
   type = string
+  default = ""
 }
 
 variable "additional_executables_list" {
   type = string
+  default = ""
 }
 
 variable "additional_executables_destination_path" {
   type = string
+  default = ""
 }
 
 variable "additional_registry_images" {
   type = string
+  default = ""
 }
 
 variable "additional_registry_images_list" {
   type = string
+  default = ""
 }
 
 variable "additional_url_images" {
   type = string
+  default = ""
 }
 
 variable "additional_url_images_list" {
   type = string
+  default = ""
 }
 
 variable "build_target" {
   type = string
+  default = ""
 }
 
 variable "containerd_additional_settings" {
   type = string
+  default = ""
 }
 
 variable "containerd_arch" {
   type = string
+  default = "amd64"
 }
 
 variable "containerd_cri_socket" {
@@ -94,6 +108,7 @@ variable "containerd_sha256" {
 
 variable "containerd_url" {
   type = string
+  default = ""
 }
 
 variable "containerd_version" {
@@ -102,30 +117,37 @@ variable "containerd_version" {
 
 variable "containerd_wasm_shims_arch" {
   type = string
+  default = ""
 }
 
 variable "containerd_wasm_shims_runtimes" {
   type = string
+  default = ""
 }
 
 variable "containerd_wasm_shims_sha256" {
   type = string
+  default = ""
 }
 
 variable "containerd_wasm_shims_url" {
   type = string
+  default = ""
 }
 
 variable "containerd_wasm_shims_version" {
   type = string
+  default = ""
 }
 
 variable "crictl_arch" {
   type = string
+  default = "amd64"
 }
 
 variable "crictl_sha256" {
   type = string
+  default = ""
 }
 
 variable "crictl_source_type" {
@@ -134,6 +156,7 @@ variable "crictl_source_type" {
 
 variable "crictl_url" {
   type = string
+  default = ""
 }
 
 variable "crictl_version" {
@@ -142,118 +165,131 @@ variable "crictl_version" {
 
 variable "disable_public_repos" {
   type = string
+  default = ""
 }
 
 variable "extra_debs" {
-  type = string
+   type = string
+   default = ""
 }
 
 variable "extra_repos" {
   type = string
+  default = ""
 }
 
 variable "extra_rpms" {
   type = string
+  default = ""
 }
 
 variable "firstboot_custom_roles_post" {
   type = string
+  default = ""
 }
 
 variable "firstboot_custom_roles_pre" {
   type = string
+  default = ""
 }
 
 variable "http_proxy" {
   type = string
+  default = ""
 }
 
 variable "https_proxy" {
   type = string
+  default = ""
 }
 
 variable "load_additional_components" {
   type = string
+  default = ""
 }
 
 variable "kubeadm_template" {
   type = string
+  default = "etc/kubeadm.yml"
 }
 
-variable "kubernetes_cni_deb_version" {
+variable "kubernetes_cni_version" {
   type = string
 }
 
 variable "kubernetes_cni_http_checksum" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_cni_http_checksum_arch" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_cni_http_source" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_cni_rpm_version" {
   type = string
-}
-
-variable "kubernetes_cni_semver" {
-  type = string
+  default = ""
 }
 
 variable "kubernetes_cni_source_type" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_container_registry" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_deb_gpg_key" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_deb_repo" {
   type = string
-}
-
-variable "kubernetes_deb_version" {
-  type = string
+  default = ""
 }
 
 variable "kubernetes_http_source" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_load_additional_imgs" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_rpm_gpg_check" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_rpm_gpg_key" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_rpm_repo" {
   type = string
+  default = ""
 }
 
 variable "kubernetes_rpm_repo_arch" {
   type = string
+  default = "x86_64"
 }
 
 variable "kubernetes_rpm_version" {
   type = string
-}
-
-variable "kubernetes_semver" {
-  type = string
+  default = ""
 }
 
 variable "kubernetes_source_type" {
@@ -262,50 +298,62 @@ variable "kubernetes_source_type" {
 
 variable "node_custom_roles_post" {
   type = string
+  default = ""
 }
 
 variable "node_custom_roles_pre" {
   type = string
+  default = ""
 }
 
 variable "no_proxy" {
   type = string
+  default = ""
 }
 
 variable "pause_image" {
   type = string
+  default = ""
 }
 
 variable "pip_conf_file" {
   type = string
+  default = ""
 }
 
 variable "python_path" {
   type = string
+  default = ""
 }
 
 variable "redhat_epel_rpm" {
   type = string
+  default = ""
 }
 
 variable "reenable_public_repos" {
   type = string
+  default = ""
 }
 
 variable "remove_extra_repos" {
   type = string
+  default = ""
 }
 
 variable "systemd_prefix" {
   type = string
+  default = "/etc/systemd"
 }
 
 variable "sysusr_prefix" {
   type = string
+  default = "/usr"
 }
 
 variable "sysusrlocal_prefix" {
   type = string
+  default = "/usr/local"
 }
 
 #####
@@ -314,6 +362,15 @@ variable "sysusrlocal_prefix" {
 
 locals {
     build_timestamp = formatdate("YYMMDD-hhmm", timestamp())
+
+    kubernetes_semver = "v${var.kubernetes_version}"
+    kubernetes_cni_semver = "v${var.kubernetes_cni_version}"
+
+    # Debian based
+    kubernetes_deb_version = "${var.kubernetes_version}-00"
+    kubernetes_cni_deb_version = "${var.kubernetes_cni_version}-00"
+
+    # Red Hat based
 
     containerd_url_default = "https://github.com/containerd/containerd/releases/download/v${var.containerd_version}/cri-containerd-cni-${var.containerd_version}-linux-${var.containerd_arch}.tar.gz"
     containerd_url = element([for e in [var.containerd_url, local.containerd_url_default]: e if e != ""], 0)
@@ -327,7 +384,7 @@ locals {
     crictl_url_default = "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${var.crictl_version}/crictl-v${var.crictl_version}-linux-${var.crictl_arch}.tar.gz"
     crictl_url = element([for e in [var.crictl_url, local.crictl_url_default]: e if e != ""], 0)
 
-    kubernetes_cni_http_checksum_default = "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/${var.kubernetes_cni_semver}/cni-plugins-linux-${var.kubernetes_cni_http_checksum_arch}-${var.kubernetes_cni_semver}.tgz.sha256"
+    kubernetes_cni_http_checksum_default = "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/${local.kubernetes_cni_semver}/cni-plugins-linux-${var.kubernetes_cni_http_checksum_arch}-${local.kubernetes_cni_semver}.tgz.sha256"
     kubernetes_cni_http_checksum = element([for e in [var.kubernetes_cni_http_checksum, local.kubernetes_cni_http_checksum_default]: e if e != ""], 0)
 
     kubernetes_rpm_repo_default = "https://packages.cloud.google.com/yum/repos/kubernetes-el7-${var.kubernetes_rpm_repo_arch}"
@@ -339,7 +396,7 @@ locals {
 #####
 
 source "openstack" "kubernetes" {
-  image_name = "${var.distro_name}-kube-${var.kubernetes_semver}-${local.build_timestamp}"
+  image_name = "${var.distro_name}-kube-${local.kubernetes_semver}-${local.build_timestamp}"
   image_visibility = "private"
   image_disk_format = "${var.disk_format}"
 
@@ -357,11 +414,16 @@ source "openstack" "kubernetes" {
 }
 
 build {
-  source "source.openstack.kubernetes" { }
+  sources = [
+      "openstack.kubernetes"
+  ]
 
   provisioner "ansible" {
     galaxy_file = "${path.root}/../requirements.yml"
     playbook_file = "${path.root}/../vendor/image-builder/images/capi/ansible/node.yml"
+    command = "ansible-playbook"
+    only = ["openstack.kubernetes"]
+    user = "ubuntu"
     use_proxy = false
     extra_arguments = [
       "-v",
@@ -426,7 +488,7 @@ build {
       "--extra-vars",
       "kubeadm_template=${var.kubeadm_template}",
       "--extra-vars",
-      "kubernetes_cni_deb_version=${var.kubernetes_cni_deb_version}",
+      "kubernetes_cni_deb_version=${local.kubernetes_cni_deb_version}",
       "--extra-vars",
       "kubernetes_cni_http_checksum=${local.kubernetes_cni_http_checksum}",
       "--extra-vars",
@@ -434,7 +496,7 @@ build {
       "--extra-vars",
       "kubernetes_cni_rpm_version=${var.kubernetes_cni_rpm_version}",
       "--extra-vars",
-      "kubernetes_cni_semver=${var.kubernetes_cni_semver}",
+      "kubernetes_cni_semver=${local.kubernetes_cni_semver}",
       "--extra-vars",
       "kubernetes_cni_source_type=${var.kubernetes_cni_source_type}",
       "--extra-vars",
@@ -444,7 +506,7 @@ build {
       "--extra-vars",
       "kubernetes_deb_repo=${var.kubernetes_deb_repo}",
       "--extra-vars",
-      "kubernetes_deb_version=${var.kubernetes_deb_version}",
+      "kubernetes_deb_version=${local.kubernetes_deb_version}",
       "--extra-vars",
       "kubernetes_http_source=${var.kubernetes_http_source}",
       "--extra-vars",
@@ -458,7 +520,7 @@ build {
       "--extra-vars",
       "kubernetes_rpm_version=${var.kubernetes_rpm_version}",
       "--extra-vars",
-      "kubernetes_semver=${var.kubernetes_semver}",
+      "kubernetes_semver=${local.kubernetes_semver}",
       "--extra-vars",
       "kubernetes_source_type=${var.kubernetes_source_type}",
       "--extra-vars",
@@ -486,7 +548,12 @@ build {
       "--extra-vars",
       "sysusrlocal_prefix=${var.sysusrlocal_prefix}",
     ]
-    ansible_env_vars = ["ANSIBLE_SSH_RETRIES=10"]
+    groups = ["all"]
+    ansible_env_vars = [
+      "ANSIBLE_SSH_RETRIES=10", 
+      "ANSIBLE_SSH_ARGS='-o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=60s'",
+      "ANSIBLE_PIPELINING=true",
+    ]
   }
 
   post-processor "manifest" {


### PR DESCRIPTION
Add defaults to some variables and move some to local block to allow definition by interpolation

This runs pretty smoothly for building an image based on Ubuntu Jammy and the image builds a working 1.27.1 cluster.

See https://gist.github.com/heytrav/802f83e8db5b58b46f8d56c87c9beca2 for example json var-files passed to packer.

```
packer build -only openstack.kubernetes -var kubernetes_version=1.27.1 \
    -var-file ubuntu-22.04.json \
    -var-file local-config.json \
    -var-file kubernetes.json \
    packer/kubernetes.pkr.hcl
```
Note: I did need to modify one Ansible task in image_builder so that unpacking the containerd archive wouldn't overwrite the /bin folder.