### PR TITLE
import_role -> include_role

### DIFF
--- a/ansible/roles/jupyter-repo2docker/tasks/main.yml
+++ b/ansible/roles/jupyter-repo2docker/tasks/main.yml
@@ -48,7 +48,7 @@
   vars:
     prometheus_data_directory: /data/prometheus/database
 
-- import_role:
+- include_role:
     name: linux-zenith-client
   vars:
     zenith_client_name: repo2docker-zenith-client

--- a/ansible/roles/linux-monitoring/tasks/main.yml
+++ b/ansible/roles/linux-monitoring/tasks/main.yml
@@ -8,7 +8,7 @@
     - prometheus_data_directory
 
 - name: Install systemd unit for monitoring pod
-  import_role: 
+  include_role: 
     name: linux-podman
     tasks_from: systemd-unit.yml
   vars:
@@ -33,7 +33,7 @@
       prometheus_podman_user: "{{ podman_service_user }}"
       
 - name: Configure monitoring Zenith client
-  import_role:
+  include_role:
     name: linux-zenith-client
   vars:
     zenith_client_name: monitoring-zenith-client

--- a/ansible/roles/linux-rdp-gateway/tasks/main.yml
+++ b/ansible/roles/linux-rdp-gateway/tasks/main.yml
@@ -45,7 +45,7 @@
     # Execute between data volumes and zenith client
     dest: /etc/ansible-init/playbooks/50-guacamole.yml
 
-- import_role:
+- include_role:
     name: linux-zenith-client
   vars:
     zenith_client_name: guacamole-zenith-client

--- a/ansible/roles/linux-webconsole/tasks/main.yml
+++ b/ansible/roles/linux-webconsole/tasks/main.yml
@@ -86,7 +86,7 @@
   vars:
     prometheus_data_directory: /data/prometheus/database
 
-- import_role:
+- include_role:
     name: linux-zenith-client
   vars:
     zenith_client_name: guacamole-zenith-client


### PR DESCRIPTION
This change fixes a subtle bug where, if the same role was imported twice within a single play (e.g. to set up two different zenith client instances) then there could be some leakage of vars between role executions. This was observered, for example, when setting `zenith_forward_to_host: HOST_IP` in one case of importing the zenith client role and having that variable be picked up in another section of the play where the role is imported a second time without this var explicitly set. The expected behaviour here was that the var would be set to the role default, but instead the var was end up being shared between separate imports of the same role so that the `HOST_IP` value was used in all invocations of the role.