### PR TITLE
Workstation on Ubuntu 22.04

### DIFF
--- a/.github/builds.yaml
+++ b/.github/builds.yaml
@@ -4,7 +4,7 @@
 
 - name: ubuntu-desktop
   template: linux-desktop
-  var-files: common,kvm,linux,ubuntu-focal
+  var-files: common,kvm,linux,ubuntu-jammy
   path-filters: |
     paths:
       - .github/workflows/pr.yml
@@ -14,11 +14,11 @@
       - env/*/common.env
       - env/*/kvm.env
       - env/*/linux.env
-      - env/*/ubuntu-focal.env
+      - env/*/ubuntu-jammy.env
       - vars/*/common.json
       - vars/*/kvm.json
       - vars/*/linux.json
-      - vars/*/ubuntu-focal.json
+      - vars/*/ubuntu-jammy.json
       - packer/linux-desktop.pkr.hcl
       - ansible/linux-webconsole.yml
       - ansible/roles/linux-webconsole/**

--- a/ansible/roles/linux-guacamole/defaults/main.yml
+++ b/ansible/roles/linux-guacamole/defaults/main.yml
@@ -4,7 +4,7 @@ guacamole_image_prefix: docker.io/guacamole
 
 # Use 1.4.0 until 1.5.1 is released
 # This is due to https://issues.apache.org/jira/browse/GUACAMOLE-1741
-guacamole_version: 1.4.0
+guacamole_version: 1.5.3
 
 guacamole_server_image_name: guacd
 guacamole_server_image_tag: "{{ guacamole_version }}"
@@ -16,7 +16,7 @@ guacamole_client_image: "{{ guacamole_image_prefix }}/{{ guacamole_client_image_
 
 guacamole_nginx_image_prefix: docker.io
 guacamole_nginx_image_name: nginx
-guacamole_nginx_image_tag: 1.22.1
+guacamole_nginx_image_tag: 1.25.1
 guacamole_nginx_image: "{{ guacamole_nginx_image_prefix }}/{{ guacamole_nginx_image_name }}:{{ guacamole_nginx_image_tag }}"
 
 guacamole_mitm_log_level: notice

--- a/ansible/roles/linux-webconsole/vars/Ubuntu.yml
+++ b/ansible/roles/linux-webconsole/vars/Ubuntu.yml
@@ -2,4 +2,4 @@
 
 desktop_environment_package: ubuntu-desktop-minimal
 
-tigervnc_server_packages: [tigervnc-standalone-server, tigervnc-xorg-extension]
+tigervnc_server_packages: [tigervnc-standalone-server, tigervnc-xorg-extension, dbus-x11]


### PR DESCRIPTION
Workstation image rebase to Ubuntu 22.04 and version bump for guacamole and nginx.

Tested on 20230828 Jammy base image from main.