### PR TITLE
repo2docker on Ubuntu 22.04

### DIFF
--- a/.github/builds.yaml
+++ b/.github/builds.yaml
@@ -57,7 +57,7 @@
 
 - name: jupyter-repo2docker
   template: jupyter-repo2docker
-  var-files: common,kvm,linux,ubuntu-focal
+  var-files: common,kvm,linux,ubuntu-jammy
   path-filters: |
     paths:
       - .github/workflows/pr.yml
@@ -67,11 +67,11 @@
       - env/*/common.env
       - env/*/kvm.env
       - env/*/linux.env
-      - env/*/ubuntu-focal.env
+      - env/*/ubuntu-jammy.env
       - vars/*/common.json
       - vars/*/kvm.json
       - vars/*/linux.json
-      - vars/*/ubuntu-focal.json
+      - vars/*/ubuntu-jammy.json
       - packer/jupyter-repo2docker.pkr.hcl
       - ansible/jupyter-repo2docker.yml
       - ansible/roles/jupyter-repo2docker/**

--- a/ansible/roles/jupyter-repo2docker/defaults/main.yml
+++ b/ansible/roles/jupyter-repo2docker/defaults/main.yml
@@ -2,3 +2,4 @@
 
 podman_service_user: "podman"
 jupyter_data_volume: "/data/jupyter"
+repo2podman_version: "85076c3dd39576686890b8e5b2900795db332273"

--- a/ansible/roles/jupyter-repo2docker/tasks/repo2docker.yml
+++ b/ansible/roles/jupyter-repo2docker/tasks/repo2docker.yml
@@ -12,9 +12,13 @@
 
 - name: Install repo2docker
   pip:
-    name: 
+    name:
       - jupyter-repo2docker
-      - repo2podman
+
+- name: Install repo2podman
+  pip:
+    name:
+      - git+https://github.com/manics/repo2podman@{{ repo2podman_version }}
 
 - name: Install systemd unit for repo2docker pod
   include_role: 


### PR DESCRIPTION
Rebase Jupyter repo2docker image to Ubuntu 22.04 LTS and pin repo2docker version at 2022.10 to fix an issue with 2023.6 causing repo2docker to fail notebook building on 20.04 and 22.04 images.

Tested on 20230828 Jammy base image from main.