### PR TITLE
Runtime directory fix for Zenith clients

### DIFF
--- a/ansible/roles/linux-guacamole/tasks/main.yml
+++ b/ansible/roles/linux-guacamole/tasks/main.yml
@@ -7,6 +7,8 @@
   vars:
     podman_service_name: guacamole
     podman_service_type: pod
+    podman_service_wants:
+      - user-runtime-dir@1001
 
 - name: Pull image for guacamole server
   containers.podman.podman_image:

--- a/ansible/roles/linux-monitoring/tasks/main.yml
+++ b/ansible/roles/linux-monitoring/tasks/main.yml
@@ -14,6 +14,8 @@
   vars:
     podman_service_name: monitoring
     podman_service_type: pod
+    podman_service_wants:
+      - user-runtime-dir@1001
 
 - name: Install node_exporter
   import_role:


### PR DESCRIPTION
Fix for the Workstation 22.04 appliance Zenith clients crashing due to the Podman user runtime directory not being activated prior to monitoring/guacamole services.

`Oct 13 10:24:48 easy-workstation-ssh podman[865]: Error: error creating tmpdir: mkdir /run/user/1001: permission denied`
`Oct 13 10:24:52 easy-workstation-ssh systemd[1]: Starting User Runtime Directory /run/user/1001...`
