### PR TITLE
Fix podman pod creation on reboot

### DIFF
--- a/.github/builds.yaml
+++ b/.github/builds.yaml
@@ -29,31 +29,31 @@
       - ansible/roles/linux-monitoring/**
       - ansible/roles/linux-zenith-client/**
 
-- name: ubuntu-rdp-gateway
-  template: linux-rdp-gateway
-  var-files: common,kvm,linux,ubuntu-focal
-  path-filters: |
-    paths:
-      - .github/workflows/pr.yml
-      - bin/*
-      - config.pkr.hcl
-      - requirements.yml
-      - env/*/common.env
-      - env/*/kvm.env
-      - env/*/linux.env
-      - env/*/ubuntu-focal.env
-      - vars/*/common.json
-      - vars/*/kvm.json
-      - vars/*/linux.json
-      - vars/*/ubuntu-focal.json
-      - packer/linux-rdp-gateway.pkr.hcl
-      - ansible/linux-rdp-gateway.yml
-      - ansible/roles/linux-rdp-gateway/**
-      - ansible/roles/linux-ansible-init/**
-      - ansible/roles/linux-podman/**
-      - ansible/roles/linux-data-volumes/**
-      - ansible/roles/linux-guacamole/**
-      - ansible/roles/linux-zenith-client/**
+# - name: ubuntu-rdp-gateway
+#   template: linux-rdp-gateway
+#   var-files: common,kvm,linux,ubuntu-focal
+#   path-filters: |
+#     paths:
+#       - .github/workflows/pr.yml
+#       - bin/*
+#       - config.pkr.hcl
+#       - requirements.yml
+#       - env/*/common.env
+#       - env/*/kvm.env
+#       - env/*/linux.env
+#       - env/*/ubuntu-focal.env
+#       - vars/*/common.json
+#       - vars/*/kvm.json
+#       - vars/*/linux.json
+#       - vars/*/ubuntu-focal.json
+#       - packer/linux-rdp-gateway.pkr.hcl
+#       - ansible/linux-rdp-gateway.yml
+#       - ansible/roles/linux-rdp-gateway/**
+#       - ansible/roles/linux-ansible-init/**
+#       - ansible/roles/linux-podman/**
+#       - ansible/roles/linux-data-volumes/**
+#       - ansible/roles/linux-guacamole/**
+#       - ansible/roles/linux-zenith-client/**
 
 - name: jupyter-repo2docker
   template: jupyter-repo2docker

--- a/ansible/roles/linux-guacamole/tasks/main.yml
+++ b/ansible/roles/linux-guacamole/tasks/main.yml
@@ -7,8 +7,6 @@
   vars:
     podman_service_name: guacamole
     podman_service_type: pod
-    podman_service_wants:
-      - user-runtime-dir@1001
 
 - name: Pull image for guacamole server
   containers.podman.podman_image:

--- a/ansible/roles/linux-monitoring/tasks/main.yml
+++ b/ansible/roles/linux-monitoring/tasks/main.yml
@@ -14,8 +14,6 @@
   vars:
     podman_service_name: monitoring
     podman_service_type: pod
-    podman_service_wants:
-      - user-runtime-dir@1001
 
 - name: Install node_exporter
   import_role:

--- a/ansible/roles/linux-podman/defaults/main.yml
+++ b/ansible/roles/linux-podman/defaults/main.yml
@@ -10,3 +10,5 @@ podman_service_group: "{{ podman_service_user }}"
 podman_unqualified_search_registries:
   - "docker.io"
   - "quay.io"
+# Pick ID that should (hopefully) never clash with others
+podman_user_id: 1600987

--- a/ansible/roles/linux-podman/defaults/main.yml
+++ b/ansible/roles/linux-podman/defaults/main.yml
@@ -11,6 +11,6 @@ podman_unqualified_search_registries:
   - "docker.io"
   - "quay.io"
 # Pick ID that should (hopefully) never clash with others
-# but also not once that clashes with systemd ranges
+# but also not one that clashes with systemd ranges
 # https://systemd.io/UIDS-GIDS/
 podman_user_id: 56780

--- a/ansible/roles/linux-podman/defaults/main.yml
+++ b/ansible/roles/linux-podman/defaults/main.yml
@@ -11,4 +11,6 @@ podman_unqualified_search_registries:
   - "docker.io"
   - "quay.io"
 # Pick ID that should (hopefully) never clash with others
-podman_user_id: 1600987
+# but also not once that clashes with systemd ranges
+# https://systemd.io/UIDS-GIDS/
+podman_user_id: 56780

--- a/ansible/roles/linux-podman/tasks/install.yml
+++ b/ansible/roles/linux-podman/tasks/install.yml
@@ -45,6 +45,7 @@
     name: podman
     home: /var/lib/podman
     uid: "{{ podman_user_id }}"
+    group: "{{ podman_user_id }}"
 
 - name: Enable linger for podman user
   command: "loginctl enable-linger podman"

--- a/ansible/roles/linux-podman/tasks/install.yml
+++ b/ansible/roles/linux-podman/tasks/install.yml
@@ -44,6 +44,7 @@
   user:
     name: podman
     home: /var/lib/podman
+    uid: "{{ podman_user_id }}"
 
 - name: Enable linger for podman user
   command: "loginctl enable-linger podman"

--- a/ansible/roles/linux-podman/tasks/install.yml
+++ b/ansible/roles/linux-podman/tasks/install.yml
@@ -45,7 +45,6 @@
     name: podman
     home: /var/lib/podman
     uid: "{{ podman_user_id }}"
-    group: "{{ podman_user_id }}"
 
 - name: Enable linger for podman user
   command: "loginctl enable-linger podman"

--- a/ansible/roles/linux-podman/templates/systemd.pod.service.j2
+++ b/ansible/roles/linux-podman/templates/systemd.pod.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 Description=Podman container-{{ podman_service_name }}.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target user@1001.service
-After=network-online.target user@1001.service
+Wants=network.target user@{{ podman_user_id }}.service
+After=network-online.target user@{{ podman_user_id }}.service
 {% for service in podman_service_wants %}
 Wants={{ service }}.service
 After={{ service }}.service

--- a/ansible/roles/linux-podman/templates/systemd.pod.service.j2
+++ b/ansible/roles/linux-podman/templates/systemd.pod.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 Description=Podman container-{{ podman_service_name }}.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
-After=network-online.target
+Wants=network.target user@1001.service
+After=network-online.target user@1001.service
 {% for service in podman_service_wants %}
 Wants={{ service }}.service
 After={{ service }}.service


### PR DESCRIPTION
Fixes issue where Zenith services failed to come back online after rebooting platform (workstation, r-studio & repo2docker). Issue seems to be that because we have `ExecStartPre=podman create pod --name <pod-name> --replace` in pod systemd unit, the pod will get completely recreated on reboot. However, we find that after reboot the pod infra container is running but all other containers in the pod have failed (with no error logged in journal). If we copy the `podman run` command from the container unit file's `ExecStart` section and run the command manually, we get
```
Error: OCI runtime error: runc create failed: invalid slice name: 
266d2cbf219e776de09d46db6156f05012d0ba7a6b08a37e62f1d3f1aac805be
```

Also, if we `podman pod inspect` the target pod, we notice
```
"CgroupParent": "/libpod_parent",
"CgroupPath": "/libpod_parent/266d2cbf219e776de09d46db6156f05012d0ba7a6b08a37e62f1d3f1aac805be"
```

whereas for a fresh appliance (pre-reboot) we have 
```
"CgroupParent": "user.slice",
"CgroupPath": "user.slice/user-libpod_pod_266d2cbf219e776de09d46db6156f05012d0ba7a6b08a37e62f1d3f1aac805be.slice"
```

So it looks like running the `podman pod create` process before the parent user cgroup is ready leads to podman just choosing some invalid cgroup structure based on the podman-assigned Pod ID (`266d2cbf219e776de09d46db6156f05012d0ba7a6b08a37e62f1d3f1aac805be` in this case).

Since this issue applies to workstation, r-studio and repo2docker appliances I think it makes most sense to fix this in the pod unit template.