### PR TITLE
Limit podman systemd unit restart rate

### DIFF
--- a/ansible/roles/linux-podman/templates/systemd.container.service.j2
+++ b/ansible/roles/linux-podman/templates/systemd.container.service.j2
@@ -17,6 +17,7 @@ After={{ service }}.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Type=simple
 Restart=always
+RestartSec=5
 User={{ podman_service_user }}
 Group={{ podman_service_group }}
 ExecStart=/usr/bin/podman run \


### PR DESCRIPTION
Fixes an issue where systemd units for podman pods would occasionally enter a `failed` state and stop attempting to restart on exit. The issue stems from the fact that the default systemd config (as seen by running`systemd-analyze cat-config /etc/systemd/system.conf` within a workstation appliance) contains
```
#DefaultRestartSec=100ms
#DefaultStartLimitIntervalSec=10s
#DefaultStartLimitBurst=5
``` 

which means that if a unit restarts 5 times within a 10 second window, no more restart attempts will be made and the unit will be marked as failed. The `RestartSec` option means that systemd will wait a minimum of 100ms between restart attempts.

This issue primarily affects zenith client pods but in a non-obvious way. The majority of the time it will take at least few seconds for each failed attempt to initialise the client-server tunnel and therefore we wont hit the limit. However, sometimes multiple connection attempts in a row will fail more quickly (e.g. when the management cluster is completely unreachable) and we will then hit the limit, causing the unit to fail and no more connection attempts to be made (even if the management cluster becomes reachable again).

When restart rate limit is hit, we see messages such as
```
systemd[1]: monitoring-zenith-client.service: Start request repeated too quickly.
```
in the journal.

I think the simplest fix here is to force systemd to wait at least 5 seconds between restarts so that we never hit the default limit.