### PR TITLE
Update ubuntu-jammy base image (20240131)

### DIFF
--- a/env/base/ubuntu-jammy.env
+++ b/env/base/ubuntu-jammy.env
@@ -1,3 +1,3 @@
-SOURCE_IMAGE_URL="https://cloud-images.ubuntu.com/releases/jammy/release-20240131/ubuntu-22.04-server-cloudimg-amd64.img"
+SOURCE_IMAGE_URL="https://cloud-images.ubuntu.com/jammy/20240131/jammy-server-cloudimg-amd64.img"
 
 PACKER_VAR_FILES="$PACKER_VAR_FILES,vars/base/ubuntu-jammy.json"

--- a/env/base/ubuntu-jammy.env
+++ b/env/base/ubuntu-jammy.env
@@ -1,3 +1,3 @@
-SOURCE_IMAGE_URL="https://cloud-images.ubuntu.com/releases/jammy/release-20240126/ubuntu-22.04-server-cloudimg-amd64.img"
+SOURCE_IMAGE_URL="https://cloud-images.ubuntu.com/releases/jammy/release-20240131/ubuntu-22.04-server-cloudimg-amd64.img"
 
 PACKER_VAR_FILES="$PACKER_VAR_FILES,vars/base/ubuntu-jammy.json"


### PR DESCRIPTION
This is to pick up:
https://ubuntu.com/security/notices/USN-6619-1