### PR TITLE
Bump containerd to address CVE-2024-21626

### DIFF
--- a/vars/base/kubernetes.json
+++ b/vars/base/kubernetes.json
@@ -1,6 +1,7 @@
 {
   "containerd_additional_settings": "",
   "containerd_arch": "amd64",
+  "containerd_sha256": "9be621c0206b5c20a1dea05fae12fc698e5083cc81f65c9d918c644090696d19",
   "containerd_url": "",
   "containerd_version": "1.7.13",
   "containerd_wasm_shims_arch": "x86_64",

--- a/vars/base/kubernetes.json
+++ b/vars/base/kubernetes.json
@@ -2,6 +2,7 @@
   "containerd_additional_settings": "",
   "containerd_arch": "amd64",
   "containerd_url": "",
+  "containerd_version": "1.7.13",
   "containerd_wasm_shims_arch": "x86_64",
   "containerd_wasm_shims_url": "",
   "crictl_sha256": "",


### PR DESCRIPTION
Bumped to 1.7.13 as advised here: https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERD-6219724