### PR TITLE
Workaround broken Ceph debian-reef url

### DIFF
--- a/ansible/roles/linux-webconsole/tasks/main.yml
+++ b/ansible/roles/linux-webconsole/tasks/main.yml
@@ -76,6 +76,8 @@
 - include_role:
     name: stackhpc.os-manila-mount
     tasks_from: install.yml
+  vars:
+    os_manila_mount_ceph_version: '18.2.1' # default debian-reef repo URL currently broken
 
 - include_role:
     name: linux-eessi


### PR DESCRIPTION
The URL `https://download.ceph.com/debian-reef/` has been replaced by `https://download.ceph.com/debian-reef_OLD/` at present. Assuming this is a bug/temporary issue, so change the version to use 18.2.1 explicitly.

Edit: bug now raised as https://tracker.ceph.com/issues/64718