### PR TITLE
Pin repo2docker and repo2podman

### DIFF
--- a/ansible/roles/jupyter-repo2docker/defaults/main.yml
+++ b/ansible/roles/jupyter-repo2docker/defaults/main.yml
@@ -2,3 +2,6 @@
 
 podman_service_user: "podman"
 jupyter_data_volume: "/data/jupyter"
+
+repo2docker_version: 2023.06.0
+repo2podman_version: 0.2.0

--- a/ansible/roles/jupyter-repo2docker/tasks/repo2docker.yml
+++ b/ansible/roles/jupyter-repo2docker/tasks/repo2docker.yml
@@ -13,8 +13,8 @@
 - name: Install repo2docker
   pip:
     name:
-      - jupyter-repo2docker
-      - repo2podman
+      - "jupyter-repo2docker=={{ repo2docker_version }}"
+      - "repo2podman=={{ repo2podman_version }}"
 
 - name: Install systemd unit for repo2docker pod
   include_role: 


### PR DESCRIPTION
The latest version of `repo2docker` - `2024.03.0` - breaks the repo2docker appliance with a `Permission denied` error.

For now, we pin to a known working version.

```
ubuntu@test-4r6nq-repo2docker:~$ sudo -u podman -i jupyter-repo2docker --image-name repo2docker-notbook-server --engine podman --no-run https://github.com/binder-examples/bokeh.git
Picked Git content provider.
Cloning into '/tmp/repo2dockerf_v0yv88'...
remote: Enumerating objects: 13, done.
remote: Counting objects: 100% (13/13), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 13 (delta 0), reused 9 (delta 0), pack-reused 0
Receiving objects: 100% (13/13), 15.71 KiB | 3.14 MiB/s, done.
Python version unspecified, using current default Python version 3.10. This will change in the future.Building conda environment for python=3.10
Using CondaBuildPack builder
Traceback (most recent call last):
  File "/usr/local/bin/jupyter-repo2docker", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/repo2docker/__main__.py", line 474, in main
    r2d.start()
  File "/usr/local/lib/python3.10/dist-packages/repo2docker/app.py", line 892, in start
    self.build()
  File "/usr/local/lib/python3.10/dist-packages/repo2docker/app.py", line 856, in build
    for l in picked_buildpack.build(
  File "/usr/local/lib/python3.10/dist-packages/repo2docker/buildpacks/base.py", line 671, in build
    yield from client.build(**build_kwargs)
  File "/usr/local/lib/python3.10/dist-packages/repo2podman/podman.py", line 459, in build
    tarf.extractall(builddir)
  File "/usr/lib/python3.10/tarfile.py", line 2257, in extractall
    self._extract_one(tarinfo, path, set_attrs=not tarinfo.isdir(),
  File "/usr/lib/python3.10/tarfile.py", line 2324, in _extract_one
    self._handle_fatal_error(e)
  File "/usr/lib/python3.10/tarfile.py", line 2320, in _extract_one
    self._extract_member(tarinfo, os.path.join(path, tarinfo.name),
  File "/usr/lib/python3.10/tarfile.py", line 2403, in _extract_member
    self.makefile(tarinfo, targetpath)
  File "/usr/lib/python3.10/tarfile.py", line 2448, in makefile
    with bltn_open(targetpath, "wb") as target:
PermissionError: [Errno 13] Permission denied: '/tmp/tmpw097iipk/src/.git/objects/pack/pack-a06434fcada51ff585872da911f357fc71f912e5.idx'
```