### PR TITLE
Stop building Kubernetes 1.26 images

### DIFF
--- a/.github/builds.yaml
+++ b/.github/builds.yaml
@@ -14,10 +14,6 @@
   template: linux-rstudio
   var-files: common,kvm,linux,ubuntu-jammy
 
-- name: kubernetes-1-26-jammy
-  template: kubernetes
-  var-files: common,kvm,linux,ubuntu-jammy,kubernetes,kubernetes_1_26
-
 - name: kubernetes-1-27-jammy
   template: kubernetes
   var-files: common,kvm,linux,ubuntu-jammy,kubernetes,kubernetes_1_27

--- a/env/base/kubernetes_1_26.env
+++ b/env/base/kubernetes_1_26.env
@@ -1,1 +1,0 @@
-PACKER_VAR_FILES="$PACKER_VAR_FILES,vars/base/kubernetes_1_26.json"

--- a/vars/base/kubernetes_1_26.json
+++ b/vars/base/kubernetes_1_26.json
@@ -1,6 +1,0 @@
-{
-    "kubernetes_deb_version": "1.26.15-1.1",
-    "kubernetes_rpm_version": "1.26.15",
-    "kubernetes_semver": "v1.26.15",
-    "kubernetes_series": "v1.26"
-}


### PR DESCRIPTION
Kubernetes 1.26 is now EOL (https://kubernetes.io/releases/#release-v1-26).