### PR TITLE
Set extra ssh options to fix hanging on long tasks

### DIFF
--- a/packer/kubernetes.pkr.hcl
+++ b/packer/kubernetes.pkr.hcl
@@ -573,6 +573,14 @@ build {
       "ubuntu_security_repo=${var.ubuntu_security_repo}",
     ]
     ansible_env_vars = ["ANSIBLE_SSH_RETRIES=10"]
+    ansible_ssh_extra_args = [
+      "-o", "ControlMaster=auto",
+      "-o", "ControlPersist=60s",
+      "-o", "IdentitiesOnly=yes",
+      "-o", "ServerAliveInterval=60",
+      "-o", "ServerAliveCountMax=30",
+      "-o", "TCPKeepAlive=yes"
+    ]
   }
 
   post-processor "manifest" {


### PR DESCRIPTION
The Ansible provisioner under current config can hang for 2+ hours due to broken SSH connections in long tasks (e.g 20+ min dkms builds https://github.com/azimuth-cloud/azimuth-images/pull/420). Set to send 30 ServerAlive packets over 30 mins to account for these long jobs.