### PR TITLE
Include sha512 checksums in manifest

### DIFF
--- a/.github/workflows/build_test_images.yaml
+++ b/.github/workflows/build_test_images.yaml
@@ -158,6 +158,7 @@ jobs:
             name: ${{ steps.publish-image.outputs.image-name }}
             url: ${{ steps.publish-image.outputs.image-url }}
             checksum: ${{ steps.publish-image.outputs.image-checksum }}
+            checksum_sha512: ${{ steps.publish-image.outputs.image-checksum-sha512 }}
             cosign-bundle-url: ${{ steps.publish-image.outputs.cosign-bundle-url }}
             image-sbom-url: ${{ steps.publish-image.outputs.image-sbom-url }}
             manifest-extra: ${{ steps.build-image.outputs.manifest-extra }}

--- a/bin/publish-image
+++ b/bin/publish-image
@@ -32,14 +32,16 @@ IMAGE_URL="${S3_HOST_PUBLIC_PATH}/${IMAGE_NAME}.qcow2"
 COSIGN_BUNDLE_URL="${S3_HOST_PUBLIC_PATH}/${IMAGE_NAME}.cosign.bundle"
 IMAGE_SBOM_URL="${S3_HOST_PUBLIC_PATH}/${IMAGE_NAME}-sbom.json"
 
-# Get the checksum of the image
+# Get the checksums of the image
 IMAGE_CHECKSUM="sha256:$(sha256sum "${IMAGE_NAME}.qcow2" | awk '{ print $1 }')"
+IMAGE_CHECKSUM_SHA512="sha512:$(sha512sum "${IMAGE_NAME}.qcow2" | awk '{ print $1 }')"
 
 # Produce outputs
 {
   echo "image-name=$IMAGE_NAME"
   echo "image-url=$IMAGE_URL"
   echo "image-checksum=$IMAGE_CHECKSUM"
+  echo "image-checksum-sha512=$IMAGE_CHECKSUM_SHA512"
   echo "image-sbom-url=$IMAGE_SBOM_URL"
   echo "cosign-bundle-url=$COSIGN_BUNDLE_URL"
 } >>"${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION
Glance's default checksum algorithm for multihash support is sha512, so is useful for verifying images already on the cloud