### PR TITLE
Increase RStudio volume to 12GB

### DIFF
--- a/packer/linux-rstudio.pkr.hcl
+++ b/packer/linux-rstudio.pkr.hcl
@@ -30,7 +30,7 @@ variable "volume_type" {
 
 variable "volume_size" {
   type = number
-  default = 10
+  default = 12
 }
 
 variable "disk_format" {


### PR DESCRIPTION
RStudio is failing to build with "no space left on device" errors with a root volume of 10GB, so increase the size to 12GB.