### PR TITLE
Bump actions to new org-wide pins

### DIFF
--- a/.github/workflows/build_test_images.yaml
+++ b/.github/workflows/build_test_images.yaml
@@ -113,7 +113,7 @@ jobs:
           SKIP_SOURCE_IMAGE: "true"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0


### PR DESCRIPTION
The org-wide pins for github actions have recently been updated [1].
This change bumps two actions to their new pins:
sigstore/cosign-installer v3 -> v4.1.1
docker/setup-qemu-action v3 -> v4.0.0

[1] https://github.com/stackhpc/github-actions-list/pull/1/changes