### PR TITLE
Blocklist esp4 esp6 and rxrpc kernel modules

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -61,6 +61,14 @@ ignore:
   - vulnerability: CVE-2026-31609
   # No fixed kernel available for Jammy [2026-05-05]
   - vulnerability: CVE-2026-43037
+  # No fixed kernel available for Jammy [2026-05-08]
+  - vulnerability: CVE-2026-31448
+  # No fixed kernel available for Jammy [2026-05-08]
+  - vulnerability: CVE-2026-31682
+  # No fixed kernel available for Jammy [2026-05-08]
+  - vulnerability: CVE-2026-31685
+  # No fixed kernel available for Jammy [2026-05-08]
+  - vulnerability: CVE-2026-43011
   # Not affected https://ubuntu.com/security/CVE-2024-45337
   - vulnerability: GHSA-v778-237x-gjrc
     package:

--- a/ansible/roles/linux-common/defaults/main.yml
+++ b/ansible/roles/linux-common/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 blacklisted_kernel_modules_default:
   - algif_aead
+  - esp4
+  - esp6
+  - rxrpc
 
 blacklisted_kernel_modules_extra: []
 


### PR DESCRIPTION
These are implicated in the "dirtyfrag" LPE (no CVE yet).