### PR TITLE
Remove unused containerd checksum

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -336,3 +336,15 @@ ignore:
   # No fixed kernel for Jammy [2026-05-18]
   # downgraded to medium by Canonical https://ubuntu.com/security/CVE-2026-43304
   - vulnerability: CVE-2026-43304
+  # Not using NFS so not affected, no fixed kernel for Jammy [2026-05-28]
+  # downgraded to medium by Canonical https://ubuntu.com/security/CVE-2026-31402
+  - vulnerability: CVE-2026-31402
+  # No fixed kernel for Jammy [2026-05-28]
+  # downgraded to medium by Canonical
+  - vulnerability: CVE-2026-31414
+  - vulnerability: CVE-2026-23455
+  - vulnerability: CVE-2026-43406
+  - vulnerability: CVE-2026-43407
+  - vulnerability: CVE-2026-43383
+  - vulnerability: CVE-2026-23240
+  - vulnerability: CVE-2026-31405

--- a/packer/kubernetes.pkr.hcl
+++ b/packer/kubernetes.pkr.hcl
@@ -112,10 +112,6 @@ variable "containerd_cri_socket" {
   type = string
 }
 
-variable "containerd_sha256" {
-  type = string
-}
-
 variable "containerd_url" {
   type = string
 }
@@ -479,8 +475,6 @@ build {
       "containerd_additional_settings=${var.containerd_additional_settings}",
       "--extra-vars",
       "containerd_cri_socket=${var.containerd_cri_socket}",
-      "--extra-vars",
-      "containerd_sha256=${var.containerd_sha256}",
       "--extra-vars",
       "containerd_url=${local.containerd_url}",
       "--extra-vars",

--- a/vars/base/kubernetes.json
+++ b/vars/base/kubernetes.json
@@ -1,7 +1,6 @@
 {
   "containerd_additional_settings": "",
   "containerd_arch": "amd64",
-  "containerd_sha256": "57228ddf39755decf93aaaeee135976657266ba4ce1cba20af8d49fab484077d",
   "containerd_url": "",
   "containerd_service_url": "",
   "containerd_version": "1.7.30",


### PR DESCRIPTION
From image-builder v0.1.47 onwards, the containerd checksum is pulled from the upstream URL directly rather than using the containerd_sha256 variable