### PR TITLE
DNM: Update containerd to 2.2.2 and fix/ignore Go CVEs

### DIFF
--- a/.github/workflows/build_test_images.yaml
+++ b/.github/workflows/build_test_images.yaml
@@ -152,6 +152,7 @@ jobs:
           output-format: table
           severity-cutoff: critical
           only-fixed: true
+          grype-version: v0.113.0
 
       - name: Publish image
         id: publish-image

--- a/vars/base/kubernetes.json
+++ b/vars/base/kubernetes.json
@@ -4,7 +4,7 @@
   "containerd_sha256": "57228ddf39755decf93aaaeee135976657266ba4ce1cba20af8d49fab484077d",
   "containerd_url": "",
   "containerd_service_url": "",
-  "containerd_version": "1.7.30",
+  "containerd_version": "2.2.2",
   "containerd_wasm_shims_arch": "x86_64",
   "containerd_wasm_shims_url": "",
   "crictl_arch": "amd64",


### PR DESCRIPTION
Updates containerd to 2.2.2 in line with current image builder version. Major version upgrade so needs careful testing. In the future we need a way to avoid this from drifting from upstream