### PR TITLE
Update Grype binary to v0.113.0

### DIFF
--- a/.github/workflows/build_test_images.yaml
+++ b/.github/workflows/build_test_images.yaml
@@ -152,6 +152,7 @@ jobs:
           output-format: table
           severity-cutoff: critical
           only-fixed: true
+          grype-version: v0.113.0
 
       - name: Publish image
         id: publish-image


### PR DESCRIPTION
New version contains changes needed to alias CVEs with GO-XXXX ID's to NVD CVE ID's correctly