### PR TITLE
Stop building Kubernetes 1.33

### DIFF
--- a/.github/builds.yaml
+++ b/.github/builds.yaml
@@ -14,10 +14,6 @@
   template: linux-rstudio
   var-files: common,kvm,linux,ubuntu-jammy
 
-- name: kubernetes-1-33-jammy
-  template: kubernetes
-  var-files: common,kvm,linux,ubuntu-jammy,kubernetes,kubernetes_amdgpu,kubernetes_1_33
-
 - name: kubernetes-1-34-jammy
   template: kubernetes
   var-files: common,kvm,linux,ubuntu-jammy,kubernetes,kubernetes_amdgpu,kubernetes_1_34

--- a/env/base/kubernetes_1_33.env
+++ b/env/base/kubernetes_1_33.env
@@ -1,1 +1,0 @@
-PACKER_VAR_FILES="$PACKER_VAR_FILES,vars/base/kubernetes_1_33.json"

--- a/vars/base/kubernetes_1_33.json
+++ b/vars/base/kubernetes_1_33.json
@@ -1,6 +1,0 @@
-{
-  "kubernetes_deb_version": "1.33.13-*",
-  "kubernetes_rpm_version": "1.33.13",
-  "kubernetes_semver": "v1.33.13",
-  "kubernetes_series": "v1.33"
-}


### PR DESCRIPTION
Kubernetes 1.33 is EOL on 2026-06-28 and 1.33.13 is the final release.