### PR TITLE
Ubuntu26 - Fix changes in Podman networking

### DIFF
--- a/ansible/roles/linux-webconsole/files/guacamole-playbook.yml
+++ b/ansible/roles/linux-webconsole/files/guacamole-playbook.yml
@@ -135,7 +135,7 @@
               <authorize username="portal" password="portal">
                   <connection name="shell">
                       <protocol>ssh</protocol>
-                      <param name="hostname">{{ ansible_default_ipv4.address }}</param>
+                      <param name="hostname">{{ 'host.containers.internal' if ansible_facts.distribution_major_version | int >= 26 else ansible_facts.default_ipv4.address }}</param>
                       <param name="port">22</param>
                       <param name="username">{{ guacamole_user }}</param>
                       <param name="private-key">{{ guacamole_ssh_private_key }}</param>
@@ -144,7 +144,7 @@
           {% if desktop_enabled %}
                   <connection name="desktop">
                       <protocol>vnc</protocol>
-                      <param name="hostname">{{ ansible_default_ipv4.address }}</param>
+                      <param name="hostname">{{ 'host.containers.internal' if ansible_facts.distribution_major_version | int >= 26 else ansible_facts.default_ipv4.address }}</param>
                       <param name="port">5901</param>
                       <param name="autoretry">3</param>
                       <param name="username">{{ guacamole_user }}</param>


### PR DESCRIPTION
Ubuntu26 uses Podman v5.7.0, where as Ubuntu24 uses v4.9.3. In Podman 5.0 the default network program was changed from "slirp4netns" to "pasta".

This change broke the network connectivity for the Guacamole container - no ssh connection was seen when the Web Console was opened.

Since it seems that pasta is the preferred network programme of choice going forward, this change amends the host IP in the guacamole user mapping, but only for Ubuntu26 and later. The change has been tested on Ubuntu22, Ubuntu24 and Ubuntu26.