### PR TITLE
Enable automatic security updates on Ubuntu images

### DIFF
--- a/ansible/roles/linux-common/defaults/main.yml
+++ b/ansible/roles/linux-common/defaults/main.yml
@@ -17,3 +17,5 @@ sysctl_options_default:
     value: '2'
 
 sysctl_options_extra: []
+
+unattended_upgrades_enabled: true

--- a/ansible/roles/linux-common/tasks/main.yml
+++ b/ansible/roles/linux-common/tasks/main.yml
@@ -60,6 +60,27 @@
     sysctl_file: "{{ item.conf_file }}"
   loop: "{{ sysctl_options_default + sysctl_options_extra }}"
 
+- name: Configure automatic security updates
+  when:
+    - ansible_os_family == "Debian"
+    - unattended_upgrades_enabled
+  block:
+    - name: Install unattended-upgrades
+      ansible.builtin.apt:
+        pkg:
+          - unattended-upgrades
+        state: present
+
+    - name: Enable automatic updates
+      ansible.builtin.copy:
+        dest: /etc/apt/apt.conf.d/20auto-upgrades
+        content: |
+          APT::Periodic::Update-Package-Lists "1";
+          APT::Periodic::Unattended-Upgrade "1";
+        mode: "0644"
+        owner: root
+        group: root
+
 - name: Clean up after ourselves
   ansible.builtin.apt:
     clean: true


### PR DESCRIPTION
## Summary

- Install `unattended-upgrades` in the `linux-common` role
- Drop `/etc/apt/apt.conf.d/20auto-upgrades` to enable periodic security updates
- Controlled by a new `unattended_upgrades_enabled` variable (default: `true`)

## Test plan

- [ ] Build an Ubuntu Jammy image and verify `unattended-upgrades` is installed
- [ ] Confirm `/etc/apt/apt.conf.d/20auto-upgrades` is present with the correct values on the resulting VM
- [ ] Verify that setting `unattended_upgrades_enabled: false` skips the configuration