### PR TITLE
Mitigate CVE-2026-46331 and CVE-2026-52943

### DIFF
--- a/ansible/roles/linux-common/defaults/main.yml
+++ b/ansible/roles/linux-common/defaults/main.yml
@@ -4,6 +4,9 @@ blacklisted_kernel_modules_default:
   - esp4
   - esp6
   - rxrpc
+  - act_pedit
+  - rds
+  - rds_tcp
 
 blacklisted_kernel_modules_extra: []
 


### PR DESCRIPTION
Mitigates pedit-COW (CVE-2026-46331) LPE exploit by disabling act_pedit module

Also disables RDS modules used as attack vector as part of CVE-2026-52943 LPE, which is less clear if we are affected by, but these modules are disabled for EL distributions due to their security track record, so makes sense to do the same here