### PR TITLE
feat(flatcar): add containerd auto-update workflow, improve pipeline observability and SBOM management

### DIFF
--- a/.github/workflows/flatcar-containerd-update.yml
+++ b/.github/workflows/flatcar-containerd-update.yml
@@ -43,12 +43,13 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Compare versions
+        env:
+          LATEST: ${{ steps.latest.outputs.version }}
+          CURRENT: ${{ steps.current.outputs.version }}
         run: |
-          latest="${{ steps.latest.outputs.version }}"
-          current="${{ steps.current.outputs.version }}"
-          echo "Latest:  ${latest}"
-          echo "Current: ${current:-<empty>}"
-          if [ "${latest}" != "${current}" ]; then
+          echo "Latest:  ${LATEST}"
+          echo "Current: ${CURRENT:-<empty>}"
+          if [ "${LATEST}" != "${CURRENT}" ]; then
             echo "-> Version changed (or first run), propose_update will proceed"
           else
             echo "-> Already up to date, skipping update"
@@ -68,15 +69,16 @@ jobs:
           persist-credentials: false
 
       - name: Update versions.json
+        env:
+          LATEST_VERSION: ${{ needs.detect_version.outputs.latest_version }}
+          CURRENT_VERSION: ${{ needs.detect_version.outputs.current_version }}
         run: |
-          echo "Updating versions.json: ${{ needs.detect_version.outputs.current_version }} -> ${{ needs.detect_version.outputs.latest_version }}"
+          echo "Updating versions.json: ${CURRENT_VERSION} -> ${LATEST_VERSION}"
           jq \
             --arg v "$LATEST_VERSION" \
             '.containerd_version = $v' \
             vars/flatcar/versions.json > /tmp/versions.json
           mv /tmp/versions.json vars/flatcar/versions.json
-        env:
-          LATEST_VERSION: ${{ needs.detect_version.outputs.latest_version }}
 
       - name: Generate app token for PR
         uses: azimuth-cloud/github-actions/generate-app-token@master

--- a/.github/workflows/flatcar-containerd-update.yml
+++ b/.github/workflows/flatcar-containerd-update.yml
@@ -1,0 +1,111 @@
+---
+name: Update Flatcar containerd version
+
+on:  # yamllint disable-line rule:truthy
+  # Allow manual executions
+  workflow_dispatch:
+  # Run nightly after flatcar-update (00:00 UTC)
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  detect_version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      latest_version: ${{ steps.latest.outputs.version }}
+      current_version: ${{ steps.current.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Get latest containerd version from sysext-bakery
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Fetching latest containerd release from flatcar/sysext-bakery..."
+          version=$(
+            gh api repos/flatcar/sysext-bakery/releases \
+              --jq '[.[] | select(.tag_name | startswith("containerd-")) | .tag_name | ltrimstr("containerd-")] | first'
+          )
+          echo "Latest containerd version in sysext-bakery: ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Get current version
+        id: current
+        run: |
+          version=$(jq -r '.containerd_version' vars/flatcar/versions.json)
+          echo "Current containerd version in versions.json: ${version:-<empty>}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Compare versions
+        run: |
+          latest="${{ steps.latest.outputs.version }}"
+          current="${{ steps.current.outputs.version }}"
+          echo "Latest:  ${latest}"
+          echo "Current: ${current:-<empty>}"
+          if [ "${latest}" != "${current}" ]; then
+            echo "-> Version changed (or first run), propose_update will proceed"
+          else
+            echo "-> Already up to date, skipping update"
+          fi
+
+  propose_update:
+    needs: detect_version
+    if: needs.detect_version.outputs.latest_version != needs.detect_version.outputs.current_version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Update versions.json
+        run: |
+          echo "Updating versions.json: ${{ needs.detect_version.outputs.current_version }} -> ${{ needs.detect_version.outputs.latest_version }}"
+          jq \
+            --arg v "$LATEST_VERSION" \
+            '.containerd_version = $v' \
+            vars/flatcar/versions.json > /tmp/versions.json
+          mv /tmp/versions.json vars/flatcar/versions.json
+        env:
+          LATEST_VERSION: ${{ needs.detect_version.outputs.latest_version }}
+
+      - name: Generate app token for PR
+        uses: azimuth-cloud/github-actions/generate-app-token@master
+        id: generate-app-token
+        with:
+          repository: ${{ github.repository }}
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - name: Propose changes via PR
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.generate-app-token.outputs.token }}
+          commit-message: >-
+            feat(flatcar): update containerd sysext to ${{ needs.detect_version.outputs.latest_version }}
+          branch: update/flatcar-containerd-${{ needs.detect_version.outputs.latest_version }}
+          delete-branch: true
+          title: >-
+            feat(flatcar): update containerd sysext to ${{ needs.detect_version.outputs.latest_version }}
+          body: |
+            Updates containerd sysext version from
+            `${{ needs.detect_version.outputs.current_version }}` to
+            `${{ needs.detect_version.outputs.latest_version }}`.
+
+            The new sysext (`containerd-${{ needs.detect_version.outputs.latest_version }}-x86-64.raw`)
+            will be fetched from [flatcar/sysext-bakery](https://github.com/flatcar/sysext-bakery)
+            and uploaded to S3 on the next run of the **Flatcar sysexts** workflow.
+
+            See https://github.com/flatcar/sysext-bakery/releases for release notes.
+          labels: |
+            automation
+            flatcar

--- a/.github/workflows/flatcar-update.yml
+++ b/.github/workflows/flatcar-update.yml
@@ -73,34 +73,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install s3cmd and libguestfs-tools
-        run: sudo apt-get update -y && sudo apt-get install -y s3cmd libguestfs-tools
+      - name: Install s3cmd
+        run: sudo apt-get update -y && sudo apt-get install -y s3cmd
 
-      - name: Download Flatcar image
+      - name: Download Flatcar image and official SBOM
         id: download_image
         run: |
-          echo "Downloading Flatcar image for version ${FLATCAR_VERSION}..."
+          echo "Downloading Flatcar image and SBOM for version ${FLATCAR_VERSION}..."
           ./bin/flatcar-download-image
         env:
           FLATCAR_VERSION: ${{ needs.detect_version.outputs.latest_version }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
-
-      - name: Mount Flatcar image
-        run: |
-          sudo mkdir -p flatcar-mount
-          sudo guestmount -a "${IMAGE_NAME}.img" -i --ro -o allow_other flatcar-mount
-        env:
-          IMAGE_NAME: ${{ steps.download_image.outputs.image-name }}
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          path: flatcar-mount
-          artifact-name: "${{ steps.download_image.outputs.image-name }}-sbom.json"
-          output-file: "${{ steps.download_image.outputs.image-name }}-sbom.json"
-          format: syft-json
 
       - name: Scan for vulnerabilities
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
@@ -110,10 +95,6 @@ jobs:
           severity-cutoff: critical
           only-fixed: true
           fail-build: "false"
-
-      - name: Unmount image
-        if: always()
-        run: sudo guestunmount flatcar-mount || true
 
       - name: Publish image
         id: publish_image

--- a/.github/workflows/flatcar-update.yml
+++ b/.github/workflows/flatcar-update.yml
@@ -25,19 +25,34 @@ jobs:
       - name: Get latest Flatcar stable version
         id: latest
         run: |
+          echo "Fetching latest Flatcar stable version from release server..."
           version=$(
             curl -fsSL \
               https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt \
               | grep '^FLATCAR_VERSION=' \
               | cut -d= -f2
           )
+          echo "Latest stable version: ${version}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Get current version
         id: current
         run: |
           version=$(jq -r '.flatcar_version' vars/flatcar/versions.json)
+          echo "Current version in versions.json: ${version:-<empty>}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Compare versions
+        run: |
+          latest="${{ steps.latest.outputs.version }}"
+          current="${{ steps.current.outputs.version }}"
+          echo "Latest:  ${latest}"
+          echo "Current: ${current:-<empty>}"
+          if [ "${latest}" != "${current}" ]; then
+            echo "-> Version changed (or first run), build_image will proceed"
+          else
+            echo "-> Already up to date, skipping build"
+          fi
 
   build_image:
     needs: detect_version
@@ -62,7 +77,9 @@ jobs:
 
       - name: Download Flatcar image
         id: download_image
-        run: ./bin/flatcar-download-image
+        run: |
+          echo "Downloading Flatcar image for version ${FLATCAR_VERSION}..."
+          ./bin/flatcar-download-image
         env:
           FLATCAR_VERSION: ${{ needs.detect_version.outputs.latest_version }}
 
@@ -99,7 +116,9 @@ jobs:
 
       - name: Publish image
         id: publish_image
-        run: ./bin/flatcar-publish-image
+        run: |
+          echo "Publishing image ${IMAGE_NAME} to S3..."
+          ./bin/flatcar-publish-image
         env:
           IMAGE_NAME: ${{ steps.download_image.outputs.image-name }}
           S3_HOST: ${{ vars.CLOUDFLARE_S3_HOST }}
@@ -125,6 +144,8 @@ jobs:
 
       - name: Update versions.json
         run: |
+          echo "Updating versions.json: ${{ needs.detect_version.outputs.current_version }} -> ${{ needs.detect_version.outputs.latest_version }}"
+          echo "Image URL: ${{ needs.build_image.outputs.image_url }}"
           jq \
             --arg v "$LATEST_VERSION" \
             --arg u "$IMAGE_URL" \

--- a/.github/workflows/flatcar-update.yml
+++ b/.github/workflows/flatcar-update.yml
@@ -43,12 +43,13 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Compare versions
+        env:
+          LATEST: ${{ steps.latest.outputs.version }}
+          CURRENT: ${{ steps.current.outputs.version }}
         run: |
-          latest="${{ steps.latest.outputs.version }}"
-          current="${{ steps.current.outputs.version }}"
-          echo "Latest:  ${latest}"
-          echo "Current: ${current:-<empty>}"
-          if [ "${latest}" != "${current}" ]; then
+          echo "Latest:  ${LATEST}"
+          echo "Current: ${CURRENT:-<empty>}"
+          if [ "${LATEST}" != "${CURRENT}" ]; then
             echo "-> Version changed (or first run), build_image will proceed"
           else
             echo "-> Already up to date, skipping build"
@@ -143,9 +144,15 @@ jobs:
           persist-credentials: false
 
       - name: Update versions.json
+        env:
+          LATEST_VERSION: ${{ needs.detect_version.outputs.latest_version }}
+          CURRENT_VERSION: ${{ needs.detect_version.outputs.current_version }}
+          IMAGE_URL: ${{ needs.build_image.outputs.image_url }}
+          IMAGE_SBOM_URL: ${{ needs.build_image.outputs.image_sbom_url }}
+          COSIGN_BUNDLE_URL: ${{ needs.build_image.outputs.cosign_bundle_url }}
         run: |
-          echo "Updating versions.json: ${{ needs.detect_version.outputs.current_version }} -> ${{ needs.detect_version.outputs.latest_version }}"
-          echo "Image URL: ${{ needs.build_image.outputs.image_url }}"
+          echo "Updating versions.json: ${CURRENT_VERSION} -> ${LATEST_VERSION}"
+          echo "Image URL: ${IMAGE_URL}"
           jq \
             --arg v "$LATEST_VERSION" \
             --arg u "$IMAGE_URL" \
@@ -154,11 +161,6 @@ jobs:
             '.flatcar_version = $v | .flatcar_image_url = $u | .flatcar_image_sbom_url = $sbom | .flatcar_cosign_bundle_url = $bundle' \
             vars/flatcar/versions.json > /tmp/versions.json
           mv /tmp/versions.json vars/flatcar/versions.json
-        env:
-          LATEST_VERSION: ${{ needs.detect_version.outputs.latest_version }}
-          IMAGE_URL: ${{ needs.build_image.outputs.image_url }}
-          IMAGE_SBOM_URL: ${{ needs.build_image.outputs.image_sbom_url }}
-          COSIGN_BUNDLE_URL: ${{ needs.build_image.outputs.cosign_bundle_url }}
 
       - name: Generate app token for PR
         uses: azimuth-cloud/github-actions/generate-app-token@master

--- a/bin/flatcar-download-image
+++ b/bin/flatcar-download-image
@@ -11,4 +11,8 @@ curl -fSL \
 bunzip2 flatcar_production_openstack_image.img.bz2
 mv flatcar_production_openstack_image.img "${image_name}.img"
 
+curl -fSL \
+  "https://stable.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_image_sbom.json" \
+  -o "${image_name}-sbom.json"
+
 echo "image-name=${image_name}" >>"${GITHUB_OUTPUT:-/dev/stdout}"

--- a/vars/flatcar/versions.json
+++ b/vars/flatcar/versions.json
@@ -1,5 +1,5 @@
 {
-  "flatcar_version": "4593.2.3",
+  "flatcar_version": "",
   "flatcar_image_url": "",
   "flatcar_image_sbom_url": "",
   "flatcar_cosign_bundle_url": "",


### PR DESCRIPTION
## Summary

- New workflow flatcar-containerd-update.yml — detects the latest containerd release available in `flatcar/sysext-bakery` nightly (01:00 UTC), compares with `containerd_version` in `vars/flatcar/versions.json`, and opens a PR when a newer version is found. The actual sysext upload to S3 is handled by the existing Flatcar sysexts workflow on the next run after merge.
- Improved observability in `flatcar-update.yml` — each version detection step now logs its result explicitly, and a new Compare versions step summarises both values and the build decision before build_image is evaluated.
- Reset `flatcar_version` in `vars/flatcar/versions.json` — clears the placeholder version so the next flatcar-update run detects a real version change and triggers build_image for the first time (the `flatcar_image_url` field was previously empty).
-  `build_image` now reuses Flatcar's own official SBOM instead of regenerating one (Flatcar publishes a signed `flatcar_production_image_sbom.json` for every stable release). `flatcar-download-image` fetches it alongside the image, `anchore/scan-action` scans it directly, and `flatcar-publish-image` uploads it to S3 unchanged. This removes the `guestmount`/`guestunmount` steps, the `libguestfs-tools` dependency and the `anchore/sbom-action` step from the job.

## How the containerd update flow works

`flatcar-containerd-update`
  └─ detect latest containerd-* tag in sysext-bakery
  └─ if version changed, then PR updating versions.json

`PR merged`
  └─ flatcar-sysexts
       └─ downloads containerd-<version>-x86-64.raw from sysext-bakery
       └─ uploads to S3
       └─ updates sysext-manifest.json → PR

## How the official SBOM is used

`build_image`
  └─ flatcar-download-image
       └─ downloads flatcar_production_openstack_image.img.bz2
       └─ downloads flatcar_production_image_sbom.json (official, signed by Flatcar)
  └─ anchore/scan-action scans the official SBOM for critical vulnerabilities
  └─ flatcar-publish-image uploads the image + the official SBOM (as-is) + cosign bundle to S3